### PR TITLE
Add context menu for waypoints

### DIFF
--- a/src/main/java/edu/wpi/first/pathui/FxUtils.java
+++ b/src/main/java/edu/wpi/first/pathui/FxUtils.java
@@ -1,0 +1,25 @@
+package edu.wpi.first.pathui;
+
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.scene.control.MenuItem;
+
+public final class FxUtils { // NOPMD util class name
+
+  private FxUtils() {
+    throw new UnsupportedOperationException("This is a utility class!");
+  }
+
+  /**
+   * Creates a menu item with the given text and event handler.
+   *
+   * @param text         the text of the menu item
+   * @param eventHandler the handler to call when the menu item is acted upon
+   */
+  public static MenuItem menuItem(String text, EventHandler<ActionEvent> eventHandler) {
+    MenuItem menuItem = new MenuItem(text);
+    menuItem.setOnAction(eventHandler);
+    return menuItem;
+  }
+
+}


### PR DESCRIPTION
Waypoints can be deleted (if they meet the criteria) and have their control vectors be hidden or made visible at will.

Pulled in a small part of FxUtils from Shuffleboard for making menu items easier to work with