### PR TITLE
Allow user to move waypoint when outside of opposite bound

### DIFF
--- a/src/main/java/edu/wpi/first/pathweaver/DragHandler.java
+++ b/src/main/java/edu/wpi/first/pathweaver/DragHandler.java
@@ -65,11 +65,13 @@ public class DragHandler {
   }
 
   private void handleWaypointDrag(DragEvent event, Waypoint wp) {
-    if (controller.checkBounds(event.getX(), event.getY())) {
+    if (controller.checkBounds(event.getX(), 0)) {
       wp.setX(event.getX());
-      wp.setY(event.getY());
-      wp.getPath().getWaypoints().forEach(Waypoint::update);
     }
+    if (controller.checkBounds(0, event.getY())) {
+      wp.setY(event.getY());
+    }
+    wp.getPath().getWaypoints().forEach(Waypoint::update);
     controller.selectWaypoint(wp, false);
   }
 


### PR DESCRIPTION
Closes #95 
If the user is outside of the y bound they may still move waypoints horizontally. This also works the other way around with the x bound and vertical movement.