### PR TITLE
Allow custom games to be defined

### DIFF
--- a/pmd-ruleset.xml
+++ b/pmd-ruleset.xml
@@ -25,6 +25,11 @@
         <exclude name="ShortVariable"/>
         <exclude name="TooManyStaticImports"/>
     </rule>
+    <rule ref="category/java/codestyle.xml/FieldNamingConventions">
+        <properties>
+            <property name="constantPattern" value="log|logger|[A-Z][A-Z_0-9]*"/>
+        </properties>
+    </rule>
     <rule ref="category/java/design.xml/TooManyMethods">
         <properties>
             <property name="maxmethods" value="11"></property>

--- a/src/main/java/edu/wpi/first/pathweaver/CreateProjectController.java
+++ b/src/main/java/edu/wpi/first/pathweaver/CreateProjectController.java
@@ -1,7 +1,5 @@
 package edu.wpi.first.pathweaver;
 
-import edu.wpi.first.pathweaver.extensions.ExtensionManager;
-
 import java.io.File;
 import java.io.IOException;
 import javafx.beans.binding.BooleanBinding;
@@ -44,8 +42,6 @@ public class CreateProjectController {
   @FXML
   private ChoiceBox<Game> game;
 
-  private final ExtensionManager extensionManager = ExtensionManager.getInstance();
-
   @FXML
   @SuppressWarnings("PMD.NcssCount")
   private void initialize() {
@@ -71,7 +67,6 @@ public class CreateProjectController {
     }
 
     game.getItems().addAll(Game.getGames());
-    game.getItems().addAll(extensionManager.refresh());
     game.converterProperty().setValue(new StringConverter<>() {
       @Override
       public String toString(Game object) {

--- a/src/main/java/edu/wpi/first/pathweaver/CreateProjectController.java
+++ b/src/main/java/edu/wpi/first/pathweaver/CreateProjectController.java
@@ -1,5 +1,7 @@
 package edu.wpi.first.pathweaver;
 
+import edu.wpi.first.pathweaver.extensions.ExtensionManager;
+
 import java.io.File;
 import java.io.IOException;
 import javafx.beans.binding.BooleanBinding;
@@ -42,7 +44,10 @@ public class CreateProjectController {
   @FXML
   private ChoiceBox<Game> game;
 
+  private final ExtensionManager extensionManager = ExtensionManager.getInstance();
+
   @FXML
+  @SuppressWarnings("PMD.NcssCount")
   private void initialize() {
     ObservableList<TextField> numericFields = FXCollections.observableArrayList(timeStep, maxVelocity,
         maxAcceleration, maxJerk, wheelBase);
@@ -65,11 +70,12 @@ public class CreateProjectController {
       setupEditProject();
     }
 
-    game.getItems().addAll(Game.values());
+    game.getItems().addAll(Game.getGames());
+    game.getItems().addAll(extensionManager.refresh());
     game.converterProperty().setValue(new StringConverter<>() {
       @Override
       public String toString(Game object) {
-        return object.toPrettyName();
+        return object.getName();
       }
 
       @Override
@@ -91,7 +97,7 @@ public class CreateProjectController {
     double jerkMax = Double.parseDouble(maxJerk.getText());
     double wheelBaseDistance = Double.parseDouble(wheelBase.getText());
     ProjectPreferences.Values values = new ProjectPreferences.Values(timeDelta, velocityMax, accelerationMax,
-        jerkMax, wheelBaseDistance, game.getValue());
+        jerkMax, wheelBaseDistance, game.getValue().getName());
     ProjectPreferences prefs = ProjectPreferences.getInstance(directory.getAbsolutePath());
     prefs.setValues(values);
     FxUtils.loadMainScreen(vBox.getScene(), getClass());
@@ -118,7 +124,7 @@ public class CreateProjectController {
     create.setText("Edit Project");
     title.setText("Edit Project");
     browse.setVisible(false);
-    game.setValue(values.getGame());
+    game.setValue(Game.fromPrettyName(values.getGameName()));
     timeStep.setText(String.valueOf(values.getTimeStep()));
     maxVelocity.setText(String.valueOf(values.getMaxVelocity()));
     maxAcceleration.setText(String.valueOf(values.getMaxAcceleration()));

--- a/src/main/java/edu/wpi/first/pathweaver/DuplicateGameException.java
+++ b/src/main/java/edu/wpi/first/pathweaver/DuplicateGameException.java
@@ -1,0 +1,11 @@
+package edu.wpi.first.pathweaver;
+
+public class DuplicateGameException extends RuntimeException {
+  public DuplicateGameException(String message) {
+    super(message);
+  }
+
+  public DuplicateGameException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/edu/wpi/first/pathweaver/Field.java
+++ b/src/main/java/edu/wpi/first/pathweaver/Field.java
@@ -45,7 +45,7 @@ public class Field {
     setCoord(new Point2D(xPixel + pixelWidth / 2 - realWidth / 2, yPixel + pixelLength / 2 - realLength / 2));
     setScale(((pixelWidth / realWidth) + (pixelLength / realLength)) / 2); //NOPMD Useless Parentheses
     setUnit(unit);
-    pixel = PathUnits.addUnit(unit.multiply(scale), "Pixel", "px");
+    pixel = unit.multiply(scale);
   }
 
   /**

--- a/src/main/java/edu/wpi/first/pathweaver/Field.java
+++ b/src/main/java/edu/wpi/first/pathweaver/Field.java
@@ -2,8 +2,9 @@ package edu.wpi.first.pathweaver;
 
 import tec.units.indriya.quantity.Quantities;
 
-import java.awt.geom.Point2D;
+import java.util.function.Supplier;
 
+import javafx.geometry.Point2D;
 import javafx.scene.image.Image;
 
 import javax.measure.Quantity;
@@ -12,6 +13,7 @@ import javax.measure.quantity.Length;
 
 
 public class Field {
+  private Supplier<Image> imageSupplier;
   private Image image;
   private Quantity<Length> rWidth;
   private Quantity<Length> rLength;
@@ -19,6 +21,32 @@ public class Field {
   private Point2D coord;
   public Unit<Length> unit;
   public Unit<Length> pixel;
+
+  /**
+   * Creates a new Field Object.
+   *
+   * @param imageSupplier a supplier for image of the field
+   * @param unit          unit which the field is measured
+   * @param realWidth     width of field in real units
+   * @param realLength    length of field in real units
+   * @param xPixel        x pixel top left x pixels
+   * @param yPixel        y pixel top left y pixels
+   * @param pixelWidth    width of drawable area in pixels
+   * @param pixelLength   length of drawable area in pixels
+   */
+  public Field(Supplier<Image> imageSupplier,
+               Unit<Length> unit,
+               double realWidth, double realLength,
+               double xPixel, double yPixel,
+               double pixelWidth, double pixelLength) {
+    this.imageSupplier = imageSupplier;
+    setRealWidth(Quantities.getQuantity(realWidth, unit));
+    setRealLength(Quantities.getQuantity(realLength, unit));
+    setCoord(new Point2D(xPixel + pixelWidth / 2 - realWidth / 2, yPixel + pixelLength / 2 - realLength / 2));
+    setScale(((pixelWidth / realWidth) + (pixelLength / realLength)) / 2); //NOPMD Useless Parentheses
+    setUnit(unit);
+    pixel = PathUnits.addUnit(unit.multiply(scale), "Pixel", "px");
+  }
 
   /**
    * Creates a new Field Object.
@@ -37,22 +65,18 @@ public class Field {
                double realWidth, double realLength,
                double xPixel, double yPixel,
                double pixelWidth, double pixelLength) {
-    setImage(image);
-    setRealWidth(Quantities.getQuantity(realWidth, unit));
-    setRealLength(Quantities.getQuantity(realLength, unit));
-    setCoord(new Point2D.Double(xPixel + pixelWidth / 2 - realWidth / 2, yPixel + pixelLength / 2 - realLength / 2));
-    setScale(((pixelWidth / realWidth) + (pixelLength / realLength)) / 2); //NOPMD Useless Parentheses
-    setUnit(unit);
-    pixel = PathUnits.addUnit(unit.multiply(scale), "Pixel", "px");
+    this(() -> image, unit, realWidth, realLength, xPixel, yPixel, pixelWidth, pixelLength);
   }
 
 
+  /**
+   * Gets the field image.
+   */
   public Image getImage() {
+    if (image == null) {
+      image = imageSupplier.get();
+    }
     return image;
-  }
-
-  private void setImage(Image image) {
-    this.image = image;
   }
 
   public Quantity<Length> getRealWidth() {

--- a/src/main/java/edu/wpi/first/pathweaver/Field.java
+++ b/src/main/java/edu/wpi/first/pathweaver/Field.java
@@ -20,7 +20,6 @@ public class Field {
   private double scale;
   private Point2D coord;
   public Unit<Length> unit;
-  public Unit<Length> pixel;
 
   /**
    * Creates a new Field Object.
@@ -45,7 +44,6 @@ public class Field {
     setCoord(new Point2D(xPixel + pixelWidth / 2 - realWidth / 2, yPixel + pixelLength / 2 - realLength / 2));
     setScale(((pixelWidth / realWidth) + (pixelLength / realLength)) / 2); //NOPMD Useless Parentheses
     setUnit(unit);
-    pixel = unit.multiply(scale);
   }
 
   /**

--- a/src/main/java/edu/wpi/first/pathweaver/Game.java
+++ b/src/main/java/edu/wpi/first/pathweaver/Game.java
@@ -1,13 +1,15 @@
 package edu.wpi.first.pathweaver;
 
+import edu.wpi.first.pathweaver.extensions.ExtensionLoader;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Supplier;
 
 import javafx.scene.image.Image;
-
-import static edu.wpi.first.pathweaver.PathUnits.FOOT;
 
 public final class Game {
 
@@ -15,7 +17,7 @@ public final class Game {
   private final Field field;
 
   private static final Set<Game> games = new LinkedHashSet<>(); // NOPMD constant name
-  public static final Game POWER_UP_2018 = create("FIRST Power Up", createPowerupField());
+  public static final Game POWER_UP_2018 = loadPowerupGame();
 
   private Game(String name, Field field) {
     this.name = name;
@@ -84,14 +86,17 @@ public final class Game {
     return games;
   }
 
-  private static Field createPowerupField() {
-    Supplier<Image> imageSupplier = () -> new Image("edu/wpi/first/pathweaver/2018-field.jpg");
-    double realWidth = 54;
-    double realLength = 27;
-    double xPixel = 125;
-    double yPixel = 20;
-    double pixelWidth = 827 - xPixel;
-    double pixelLength = 370 - yPixel;
-    return new Field(imageSupplier, FOOT, realWidth, realLength, xPixel, yPixel, pixelWidth, pixelLength);
+  private static Game loadPowerupGame() {
+    String jsonText;
+    try (var reader = new InputStreamReader(Game.class.getResourceAsStream("2018-powerup.json"))) {
+      StringWriter writer = new StringWriter();
+      reader.transferTo(writer);
+      jsonText = writer.toString();
+      writer.close();
+    } catch (IOException e) {
+      throw new IllegalStateException("Could not load the Powerup game definition", e);
+    }
+    ExtensionLoader loader = new ExtensionLoader();
+    return loader.loadFromJsonString(name -> new Image(Game.class.getResourceAsStream("2018-field.jpg")), jsonText);
   }
 }

--- a/src/main/java/edu/wpi/first/pathweaver/Game.java
+++ b/src/main/java/edu/wpi/first/pathweaver/Game.java
@@ -1,28 +1,97 @@
 package edu.wpi.first.pathweaver;
 
-public enum Game {
-  POWER_UP_2018("FIRST Power Up");
-  private String prettyName;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
 
-  Game(String prettyName) {
-    this.prettyName = prettyName;
-  }
+import javafx.scene.image.Image;
 
-  public String toPrettyName() {
-    return prettyName;
+import static edu.wpi.first.pathweaver.PathUnits.FOOT;
+
+public final class Game {
+
+  private final String name;
+  private final Field field;
+
+  private static final Set<Game> games = new LinkedHashSet<>(); // NOPMD constant name
+  public static final Game POWER_UP_2018 = create("FIRST Power Up", createPowerupField());
+
+  private Game(String name, Field field) {
+    this.name = name;
+    this.field = field;
   }
 
   /**
-   * Returns the Game associated with a given prettyName.
-   * @param prettyName The prettyName of the associated Game.
-   * @return Game for prettyName.
+   * Creates and registers a new game.
+   *
+   * @param name  the name of the game
+   * @param field the game field
+   *
+   * @return the created game
+   *
+   * @throws DuplicateGameException if a game has already been created with the given name
    */
-  public static Game fromPrettyName(String prettyName) {
-    for (Game game : values()) {
-      if (game.prettyName.equals(prettyName)) {
-        return game;
-      }
+  public static Game create(String name, Field field) throws DuplicateGameException {
+    if (games.stream().map(Game::getName).anyMatch(name::equals)) {
+      throw new DuplicateGameException("A game already exists with the name \"" + name + "\"");
     }
-    return null;
+    Game game = new Game(name, field);
+    games.add(game);
+    return game;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Field getField() {
+    return field;
+  }
+
+  /**
+   * Gets the game with the given name, or null if no registered game has that name.
+   *
+   * @param name the name of the game to search for (case sensitive)
+   *
+   * @return the name with the given name
+   */
+  public static Game fromPrettyName(String name) {
+    return games.stream()
+        .filter(game -> game.getName().equals(name))
+        .findFirst()
+        .orElse(null);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    Game that = (Game) obj;
+    return Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+
+  public static Set<Game> getGames() {
+    return games;
+  }
+
+  private static Field createPowerupField() {
+    Supplier<Image> imageSupplier = () -> new Image("edu/wpi/first/pathweaver/2018-field.jpg");
+    double realWidth = 54;
+    double realLength = 27;
+    double xPixel = 125;
+    double yPixel = 20;
+    double pixelWidth = 827 - xPixel;
+    double pixelLength = 370 - yPixel;
+    return new Field(imageSupplier, FOOT, realWidth, realLength, xPixel, yPixel, pixelWidth, pixelLength);
   }
 }

--- a/src/main/java/edu/wpi/first/pathweaver/Game.java
+++ b/src/main/java/edu/wpi/first/pathweaver/Game.java
@@ -97,6 +97,6 @@ public final class Game {
       throw new IllegalStateException("Could not load the Powerup game definition", e);
     }
     ExtensionLoader loader = new ExtensionLoader();
-    return loader.loadFromJsonString(name -> new Image(Game.class.getResourceAsStream("2018-field.jpg")), jsonText);
+    return loader.loadFromJsonString(name -> new Image(Game.class.getResourceAsStream(name)), jsonText);
   }
 }

--- a/src/main/java/edu/wpi/first/pathweaver/PathDisplayController.java
+++ b/src/main/java/edu/wpi/first/pathweaver/PathDisplayController.java
@@ -1,5 +1,7 @@
 package edu.wpi.first.pathweaver;
 
+import edu.wpi.first.pathweaver.extensions.ExtensionManager;
+
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -36,7 +38,7 @@ public class PathDisplayController {
   private final ObjectProperty<Waypoint> selectedWaypoint = new SimpleObjectProperty<>();
 
   private final ObjectProperty<Path> currentPath = new SimpleObjectProperty<>();
-  private final Field field = ProjectPreferences.getInstance().getField();
+  private Field field;
 
   private final ObservableList<Path> pathList = FXCollections.observableArrayList();
   private String pathDirectory;
@@ -54,7 +56,8 @@ public class PathDisplayController {
 
   @FXML
   private void initialize() {
-
+    ExtensionManager.getInstance().refresh();
+    field = ProjectPreferences.getInstance().getField();
     Image image = field.getImage();
     backgroundImage.setImage(image);
     topPane.getStyleClass().add("pane");

--- a/src/main/java/edu/wpi/first/pathweaver/PathDisplayController.java
+++ b/src/main/java/edu/wpi/first/pathweaver/PathDisplayController.java
@@ -1,7 +1,5 @@
 package edu.wpi.first.pathweaver;
 
-import edu.wpi.first.pathweaver.extensions.ExtensionManager;
-
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -56,7 +54,6 @@ public class PathDisplayController {
 
   @FXML
   private void initialize() {
-    ExtensionManager.getInstance().refresh();
     field = ProjectPreferences.getInstance().getField();
     Image image = field.getImage();
     backgroundImage.setImage(image);

--- a/src/main/java/edu/wpi/first/pathweaver/PathUnits.java
+++ b/src/main/java/edu/wpi/first/pathweaver/PathUnits.java
@@ -68,15 +68,21 @@ public final class PathUnits extends AbstractSystemOfUnits {
     switch (unit.toLowerCase(Locale.US)) {
       // Metric
       case "meter":
+      case "metre":
       case "meters":
+      case "metres":
       case "m":
         return METER;
       case "centimeter":
+      case "centimetre":
       case "centimeters":
+      case "centimetres":
       case "cm":
         return CENTIMETER;
       case "millimeter":
+      case "millimetre":
       case "millimeters":
+      case "millimetres":
       case "mm":
         return MILLIMETER;
       // Imperial

--- a/src/main/java/edu/wpi/first/pathweaver/PathUnits.java
+++ b/src/main/java/edu/wpi/first/pathweaver/PathUnits.java
@@ -5,10 +5,11 @@ import tec.units.ri.AbstractSystemOfUnits;
 import tec.units.ri.AbstractUnit;
 import tec.units.ri.format.SimpleUnitFormat;
 
+import java.util.Locale;
+
 import javax.measure.Unit;
 import javax.measure.quantity.Length;
 import javax.measure.quantity.Time;
-import javax.measure.spi.SystemOfUnits;
 
 public final class PathUnits extends AbstractSystemOfUnits {
   private static final String SYSTEM_NAME = "PathWeaver Units";
@@ -36,7 +37,7 @@ public final class PathUnits extends AbstractSystemOfUnits {
     return SYSTEM_NAME;
   }
 
-  public static SystemOfUnits getInstance() {
+  public static PathUnits getInstance() {
     return INSTANCE;
   }
 
@@ -55,4 +56,49 @@ public final class PathUnits extends AbstractSystemOfUnits {
     }
     return unit;
   }
+
+  /**
+   * Gets the unit of length with the given name, case-insensitive.
+   *
+   * @param unit the name of the unit of length to get
+   *
+   * @throws IllegalArgumentException if no such unit exists
+   */
+  public Unit<Length> length(String unit) { // NOPMD it's a giant switch statement
+    switch (unit.toLowerCase(Locale.US)) {
+      // Metric
+      case "meter":
+      case "meters":
+      case "m":
+        return METER;
+      case "centimeter":
+      case "centimeters":
+      case "cm":
+        return CENTIMETER;
+      case "millimeter":
+      case "millimeters":
+      case "mm":
+        return MILLIMETER;
+      // Imperial
+      case "inch":
+      case "inches":
+      case "in":
+        return INCH;
+      case "foot":
+      case "feet":
+      case "ft":
+        return FOOT;
+      case "yard":
+      case "yards":
+      case "yd":
+        return YARD;
+      case "mile":
+      case "miles":
+      case "mi":
+        return MILE;
+      default:
+        throw new IllegalArgumentException("Unsupported length unit: " + unit);
+    }
+  }
+
 }

--- a/src/main/java/edu/wpi/first/pathweaver/PathWeaver.java
+++ b/src/main/java/edu/wpi/first/pathweaver/PathWeaver.java
@@ -1,5 +1,7 @@
 package edu.wpi.first.pathweaver;
 
+import edu.wpi.first.pathweaver.extensions.ExtensionManager;
+
 import java.io.IOException;
 
 import javafx.application.Application;
@@ -11,6 +13,7 @@ import javafx.stage.Stage;
 public class PathWeaver extends Application {
   @Override
   public void start(Stage primaryStage) throws IOException {
+    ExtensionManager.getInstance().refresh();
     Pane root = FXMLLoader.load(getClass().getResource("welcomeScreen.fxml"));
     Scene scene = new Scene(root);
     primaryStage.setTitle("PathWeaver - " + getVersion());

--- a/src/main/java/edu/wpi/first/pathweaver/ProjectPreferences.java
+++ b/src/main/java/edu/wpi/first/pathweaver/ProjectPreferences.java
@@ -11,9 +11,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javafx.scene.image.Image;
-
-import static edu.wpi.first.pathweaver.PathUnits.FOOT;
 
 public class ProjectPreferences {
 
@@ -37,7 +34,7 @@ public class ProjectPreferences {
   }
 
   private void setDefaults() {
-    values = new Values(0.2, 10.0, 60.0, 60.0, 2.0, Game.POWER_UP_2018);
+    values = new Values(0.2, 10.0, 60.0, 60.0, 2.0, Game.POWER_UP_2018.getName());
     updateValues();
   }
 
@@ -97,22 +94,15 @@ public class ProjectPreferences {
    * @return Field for project's game year.
    */
   public Field getField() {
-    if (values.getGame() == null) {
-      values.game = Game.POWER_UP_2018;
+    if (values.getGameName() == null) {
+      values.gameName = Game.POWER_UP_2018.getName();
       updateValues();
     }
-    switch (values.getGame()) {
-      case POWER_UP_2018:
-      default:
-        Image image = new Image("edu/wpi/first/pathweaver/2018-field.jpg");
-        double realWidth = 54;
-        double realLength = 27;
-        double xPixel = 125;
-        double yPixel = 20;
-        double pixelWidth = 827 - xPixel;
-        double pixelLength = 370 - yPixel;
-        return new Field(image, FOOT, realWidth, realLength, xPixel, yPixel, pixelWidth, pixelLength);
+    Game game = Game.fromPrettyName(values.gameName);
+    if (game == null) {
+      throw new UnsupportedOperationException("The referenced game is unknown: \"" + values.gameName + "\"");
     }
+    return game.getField();
   }
 
   public Values getValues() {
@@ -125,7 +115,7 @@ public class ProjectPreferences {
     private final double maxAcceleration;
     private final double maxJerk;
     private final double wheelBase;
-    private Game game;
+    private String gameName;
 
     /**
      * Constructor for Values of ProjectPreferences.
@@ -134,16 +124,16 @@ public class ProjectPreferences {
      * @param maxAcceleration The maximum acceleration to use
      * @param maxJerk         The maximum jerk (acceleration per second) to use
      * @param wheelBase       The width between the individual sides of the drivebase
-     * @param game            The year/FRC game
+     * @param gameName            The year/FRC game
      */
     public Values(double timeStep, double maxVelocity, double maxAcceleration, double maxJerk,
-                  double wheelBase, Game game) {
+                  double wheelBase, String gameName) {
       this.timeStep = timeStep;
       this.maxVelocity = maxVelocity;
       this.maxAcceleration = maxAcceleration;
       this.maxJerk = maxJerk;
       this.wheelBase = wheelBase;
-      this.game = game;
+      this.gameName = gameName;
     }
 
     public double getTimeStep() {
@@ -166,8 +156,8 @@ public class ProjectPreferences {
       return wheelBase;
     }
 
-    public Game getGame() {
-      return game;
+    public String getGameName() {
+      return gameName;
     }
   }
 }

--- a/src/main/java/edu/wpi/first/pathweaver/extensions/ExtensionLoader.java
+++ b/src/main/java/edu/wpi/first/pathweaver/extensions/ExtensionLoader.java
@@ -21,6 +21,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -69,6 +71,8 @@ public final class ExtensionLoader {
   public static final String BOTTOM_RIGHT_KEY = "bottom-right";
   public static final String FIELD_SIZE_KEY = "field-size";
   public static final String FIELD_UNITS_KEY = "field-unit";
+
+  private static final Logger log = Logger.getLogger(ExtensionLoader.class.getName());
 
   /**
    * Loads a game + field image extension from a JSON file.
@@ -157,7 +161,27 @@ public final class ExtensionLoader {
       }
     }
 
-    return loadFromDir(dir);
+    try {
+      return loadFromDir(dir);
+    } finally {
+      // Make sure to clean up the temp files, even if an exception is thrown when attempting to load from the temp dir
+      try {
+        deleteDir(dir);
+      } catch (IOException e) {
+        log.log(Level.WARNING, "Could not delete temp directory " + dir, e);
+      }
+    }
+  }
+
+  private static void deleteDir(Path dir) throws IOException {
+    for (Path child : Files.list(dir).collect(Collectors.toList())) {
+      if (Files.isDirectory(child)) {
+        deleteDir(child);
+      } else {
+        Files.delete(child);
+      }
+    }
+    Files.delete(dir);
   }
 
   /**

--- a/src/main/java/edu/wpi/first/pathweaver/extensions/ExtensionLoader.java
+++ b/src/main/java/edu/wpi/first/pathweaver/extensions/ExtensionLoader.java
@@ -222,12 +222,18 @@ public final class ExtensionLoader {
     @Override
     public Game deserialize(JsonElement element, Type t, JsonDeserializationContext c) throws JsonParseException {
       var jsonObject = element.getAsJsonObject();
-      String gameName = jsonObject
-          .get(GAME_NAME_KEY)
-          .getAsString();
 
       String imagePath = jsonObject
           .get(FIELD_IMAGE_KEY)
+          .getAsString();
+
+      Image image = imageProvider.apply(imagePath);
+      if (image != null && image.isError()) {
+        throw new JsonParseException("Invalid or nonexistent image: " + imagePath, image.getException());
+      }
+
+      String gameName = jsonObject
+          .get(GAME_NAME_KEY)
           .getAsString();
 
       var corners = jsonObject.get(FIELD_CORNERS_KEY).getAsJsonObject();
@@ -236,11 +242,6 @@ public final class ExtensionLoader {
 
       Point2D fieldSize = jsonArrayToPoint(jsonObject.get(FIELD_SIZE_KEY).getAsJsonArray());
       String fieldUnit = jsonObject.get(FIELD_UNITS_KEY).getAsString();
-
-      Image image = imageProvider.apply(imagePath);
-      if (image.isError()) {
-        throw new JsonParseException("Invalid or nonexistent image: " + imagePath, image.getException());
-      }
       Field field = new Field(
           image,
           PathUnits.getInstance().length(fieldUnit),

--- a/src/main/java/edu/wpi/first/pathweaver/extensions/ExtensionLoader.java
+++ b/src/main/java/edu/wpi/first/pathweaver/extensions/ExtensionLoader.java
@@ -90,8 +90,7 @@ public final class ExtensionLoader {
   }
 
   private static Image loadImage(Path dir, String fileName) {
-    String url = "file://" + dir.resolve(fileName).toAbsolutePath().toString();
-    return new Image(url);
+    return new Image(dir.resolve(fileName).toAbsolutePath().toUri().toString());
   }
 
   /**

--- a/src/main/java/edu/wpi/first/pathweaver/extensions/ExtensionLoader.java
+++ b/src/main/java/edu/wpi/first/pathweaver/extensions/ExtensionLoader.java
@@ -244,8 +244,8 @@ public final class ExtensionLoader {
           fieldSize.getY(),
           topLeftPoint.getX(),
           topLeftPoint.getY(),
-          bottomRightPoint.getX(),
-          bottomRightPoint.getY()
+          bottomRightPoint.getX() - topLeftPoint.getX(),
+          bottomRightPoint.getY() - topLeftPoint.getY()
       );
 
       return Game.create(gameName, field);

--- a/src/main/java/edu/wpi/first/pathweaver/extensions/ExtensionLoader.java
+++ b/src/main/java/edu/wpi/first/pathweaver/extensions/ExtensionLoader.java
@@ -237,8 +237,12 @@ public final class ExtensionLoader {
       Point2D fieldSize = jsonArrayToPoint(jsonObject.get(FIELD_SIZE_KEY).getAsJsonArray());
       String fieldUnit = jsonObject.get(FIELD_UNITS_KEY).getAsString();
 
+      Image image = imageProvider.apply(imagePath);
+      if (image.isError()) {
+        throw new JsonParseException("Invalid or nonexistent image: " + imagePath, image.getException());
+      }
       Field field = new Field(
-          imageProvider.apply(imagePath),
+          image,
           PathUnits.getInstance().length(fieldUnit),
           fieldSize.getX(),
           fieldSize.getY(),

--- a/src/main/java/edu/wpi/first/pathweaver/extensions/ExtensionLoader.java
+++ b/src/main/java/edu/wpi/first/pathweaver/extensions/ExtensionLoader.java
@@ -36,7 +36,7 @@ import javafx.scene.image.Image;
  * <h3>JSON structure</h3>
  * <pre>{@code
  * {
- *   "game": "gane name",
+ *   "game": "game name",
  *   "field-image": "relative/path/to/img.png",
  *   "field-corners": {
  *     "top-left": [x, y],

--- a/src/main/java/edu/wpi/first/pathweaver/extensions/ExtensionLoader.java
+++ b/src/main/java/edu/wpi/first/pathweaver/extensions/ExtensionLoader.java
@@ -1,0 +1,230 @@
+package edu.wpi.first.pathweaver.extensions;
+
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+import edu.wpi.first.pathweaver.DuplicateGameException;
+import edu.wpi.first.pathweaver.Field;
+import edu.wpi.first.pathweaver.Game;
+import edu.wpi.first.pathweaver.PathUnits;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import javafx.geometry.Point2D;
+import javafx.scene.image.Image;
+
+/**
+ * Loads game extensions. Extensions are defined by a JSON file and an image file for the field.
+ *
+ * <h3>JSON structure</h3>
+ * <pre>{@code
+ * {
+ *   "game": "gane name",
+ *   "field-image": "relative/path/to/img.png",
+ *   "field-corners": {
+ *     "top-left": [x, y],
+ *     "bottom-right": [x, y]
+ *   },
+ *   "field-size": [width, length],
+ *   "field-unit": "unit name"
+ * }
+ * }</pre>
+ * <br>The path to the field image is relative to the JSON file.
+ * <br>The field corners are the X and Y coordinates of the top-left and bottom-right pixels defining the rectangular
+ * boundary of the playable area in the field image. Non-rectangular playing areas are not supported.
+ * <br>The field size is the width and length of the playable area of the field in the provided units.
+ * <br>The field units are not case-sensitive and can be one of:
+ * <table>
+ * <tr><th>Unit</th><th>Accepted Values</th></tr>
+ * <tr><td>Meter</td><td>"meter", "meters", "m"</td></tr>
+ * <tr><td>Centimeter</td><td>"centimeter", "centimeters", "cm"</td></tr>
+ * <tr><td>Millimeter</td><td>"millimeter", "millimeters", "mm"</td></tr>
+ * <tr><td>Inch</td><td>"inch", "inches", "in"</td></tr>
+ * <tr><td>Foot</td><td>"foot", "feet", "ft"</td></tr>
+ * <tr><td>Yard</td><td>"yard", "yards", "yd"</td></tr>
+ * <tr><td>Mile</td><td>"mile", "miles", "mi"</td></tr>
+ * </table>
+ */
+public final class ExtensionLoader {
+
+  public static final String GAME_NAME_KEY = "game";
+  public static final String FIELD_IMAGE_KEY = "field-image";
+  public static final String FIELD_CORNERS_KEY = "field-corners";
+  public static final String TOP_LEFT_KEY = "top-left";
+  public static final String BOTTOM_RIGHT_KEY = "bottom-right";
+  public static final String FIELD_SIZE_KEY = "field-size";
+  public static final String FIELD_UNITS_KEY = "field-unit";
+
+  /**
+   * Loads a game + field image extension from a JSON file.
+   *
+   * @param jsonFile the JSON extension file.
+   *
+   * @throws IOException if the file could not be read
+   */
+  public Game loadFromJsonFile(Path jsonFile) throws IOException, DuplicateGameException {
+    if (!jsonFile.getFileName().toString().endsWith(".json")) {
+      throw new IllegalArgumentException("Not a JSON file: " + jsonFile);
+    }
+    String json = Files.readString(jsonFile, StandardCharsets.UTF_8);
+    return loadFromJsonString(fileName -> loadImage(jsonFile.getParent(), fileName), json);
+  }
+
+  private static Image loadImage(Path dir, String fileName) {
+    String url = "file://" + dir.resolve(fileName).toAbsolutePath().toString();
+    return new Image(url);
+  }
+
+  /**
+   * Loads a game from a directory. If there are multiple JSON files in the directory, one of them <i>must</i> be named
+   * "game.json". If not, an IllegalArgumentException is thrown. If only one JSON file is in the directory,
+   * it may have any name (but must still end with ".json").
+   *
+   * <p>This is not recursive: only the files contained in the directory are looked at.
+   *
+   * @param dir the directory to load a game from
+   *
+   * @return the game object defined in the directory
+   *
+   * @throws IOException              if files in the directory could not be read
+   * @throws DuplicateGameException   if a game already exists with the name specified in the game JSON
+   * @throws IllegalArgumentException if there are no JSON files in the directory
+   * @throws IllegalArgumentException if there are multiple JSON files in the directory and none named "game.json"
+   */
+  public Game loadFromDir(Path dir) throws IOException, DuplicateGameException {
+    List<Path> possibleJsonFiles = Files.list(dir)
+        .filter(path -> path.toString().endsWith(".json"))
+        .collect(Collectors.toList());
+    if (possibleJsonFiles.isEmpty()) {
+      throw new IllegalArgumentException("No JSON files present in the root directory");
+    }
+
+    Optional<Path> gameJson = possibleJsonFiles
+        .stream()
+        .filter(path -> path.getFileName().toString().equals("game.json"))
+        .findFirst();
+    if (gameJson.isPresent()) {
+      return loadFromJsonFile(gameJson.get());
+    } else if (possibleJsonFiles.size() == 1) {
+      return loadFromJsonFile(possibleJsonFiles.get(0));
+    } else {
+      throw new IllegalArgumentException("Cannot determine the JSON file to use");
+    }
+  }
+
+  /**
+   * Loads a game from a zip file. The zip file is expected to have the same structure as a valid directory to load
+   * from.
+   *
+   * @param zipFile the extension zip file to load
+   *
+   * @return the game object defined in the zip file
+   *
+   * @throws IOException              if files in the zip file could not be read
+   * @throws DuplicateGameException   if a game already exists with the name specified in the game JSON
+   * @throws IllegalArgumentException if there are no JSON files in the zip file
+   * @throws IllegalArgumentException if there are multiple JSON files in the zip file and none named "game.json"
+   * @see #loadFromDir(Path)
+   */
+  public Game loadFromZip(Path zipFile) throws IOException, DuplicateGameException {
+    Path dir = Files.createTempDirectory("pathweaver-extension-" + zipFile.getFileName());
+
+    try (ZipFile zip = new ZipFile(zipFile.toFile())) {
+      for (ZipEntry entry : Collections.list(zip.entries())) {
+        if (entry.isDirectory()) {
+          Files.createDirectories(dir.resolve(entry.getName()));
+        } else {
+          Path dst = dir.resolve(entry.getName());
+          try (var in = zip.getInputStream(entry); var out = Files.newOutputStream(dst)) {
+            in.transferTo(out);
+          }
+        }
+      }
+    }
+
+    return loadFromDir(dir);
+  }
+
+  /**
+   * Loads a game from a JSON string.
+   *
+   * @param imageProvider supplies an {@code Image} object given the name of an image file
+   * @param json          the JSON string to parse
+   *
+   * @return the game object defined by the JSON text
+   *
+   * @throws DuplicateGameException if a game already exists with the given name
+   */
+  public Game loadFromJsonString(Function<String, Image> imageProvider, String json) throws DuplicateGameException {
+    return new GsonBuilder()
+        .registerTypeAdapter(Game.class, new ExtensionJsonDeserializer(imageProvider))
+        .create()
+        .fromJson(json, Game.class);
+  }
+
+  private static Point2D jsonArrayToPoint(JsonArray array) {
+    if (array.size() != 2) {
+      throw new JsonParseException("Expected two elements [x, y]; got " + array);
+    }
+    return new Point2D(
+        array.get(0).getAsDouble(),
+        array.get(1).getAsDouble()
+    );
+  }
+
+  private static final class ExtensionJsonDeserializer implements JsonDeserializer<Game> {
+
+    private final Function<String, Image> imageProvider;
+
+    private ExtensionJsonDeserializer(Function<String, Image> imageProvider) {
+      this.imageProvider = imageProvider;
+    }
+
+    @Override
+    public Game deserialize(JsonElement element, Type t, JsonDeserializationContext c) throws JsonParseException {
+      var jsonObject = element.getAsJsonObject();
+      String gameName = jsonObject
+          .get(GAME_NAME_KEY)
+          .getAsString();
+
+      String imagePath = jsonObject
+          .get(FIELD_IMAGE_KEY)
+          .getAsString();
+
+      var corners = jsonObject.get(FIELD_CORNERS_KEY).getAsJsonObject();
+      Point2D topLeftPoint = jsonArrayToPoint(corners.get(TOP_LEFT_KEY).getAsJsonArray());
+      Point2D bottomRightPoint = jsonArrayToPoint(corners.get(BOTTOM_RIGHT_KEY).getAsJsonArray());
+
+      Point2D fieldSize = jsonArrayToPoint(jsonObject.get(FIELD_SIZE_KEY).getAsJsonArray());
+      String fieldUnit = jsonObject.get(FIELD_UNITS_KEY).getAsString();
+
+      Field field = new Field(
+          imageProvider.apply(imagePath),
+          PathUnits.getInstance().length(fieldUnit),
+          fieldSize.getX(),
+          fieldSize.getY(),
+          topLeftPoint.getX(),
+          topLeftPoint.getY(),
+          bottomRightPoint.getX(),
+          bottomRightPoint.getY()
+      );
+
+      return Game.create(gameName, field);
+    }
+  }
+}

--- a/src/main/java/edu/wpi/first/pathweaver/extensions/ExtensionManager.java
+++ b/src/main/java/edu/wpi/first/pathweaver/extensions/ExtensionManager.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 
 public final class ExtensionManager {
 
-  private static final Logger log = Logger.getLogger(ExtensionManager.class.getName()); // NOPMD constant name
+  private static final Logger log = Logger.getLogger(ExtensionManager.class.getName());
 
   private final String directory = System.getProperty("user.home") + "/PathWeaver/Games";
   private final ExtensionLoader loader = new ExtensionLoader();

--- a/src/main/java/edu/wpi/first/pathweaver/extensions/ExtensionManager.java
+++ b/src/main/java/edu/wpi/first/pathweaver/extensions/ExtensionManager.java
@@ -1,0 +1,111 @@
+package edu.wpi.first.pathweaver.extensions;
+
+import edu.wpi.first.pathweaver.DuplicateGameException;
+import edu.wpi.first.pathweaver.Game;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+public final class ExtensionManager {
+
+  private static final Logger log = Logger.getLogger(ExtensionManager.class.getName()); // NOPMD constant name
+
+  private final String directory = System.getProperty("user.home") + "/PathWeaver/Games";
+  private final ExtensionLoader loader = new ExtensionLoader();
+
+  private final List<Game> games = new ArrayList<>();
+
+  private static final ExtensionManager instance = new ExtensionManager(); // NOPMD constant name
+
+  public ExtensionManager() {
+    new File(directory).mkdirs();
+  }
+
+  public static ExtensionManager getInstance() {
+    return instance;
+  }
+
+  /**
+   * Gets a list of the games in the ~/PathWeaver/Games directory.
+   *
+   * @throws IOException if the games directory could not be read
+   */
+  public List<Game> findGames() throws IOException {
+    List<Game> games = new ArrayList<>();
+
+    Files.list(Paths.get(directory))
+        .filter(Files::isDirectory)
+        .map(this::loadGameFromDir)
+        .flatMap(Optional::stream)
+        .forEach(games::add);
+
+    scanForZips().stream()
+        .map(this::loadGameFromZip)
+        .flatMap(Optional::stream)
+        .forEach(games::add);
+    return games;
+  }
+
+  private Optional<Game> loadGameFromDir(Path dir) {
+    try {
+      return Optional.of(loader.loadFromDir(dir));
+    } catch (IOException e) {
+      log.log(Level.WARNING, "Could not load game from " + dir.toAbsolutePath(), e);
+    } catch (DuplicateGameException e) {
+      log.warning("Duplicate game name in " + dir.toAbsolutePath() + ": " + e.getMessage());
+    } catch (RuntimeException e) { // NOPMD
+      log.log(Level.WARNING, "General exception when loading from " + dir.toAbsolutePath(), e);
+    }
+    return Optional.empty();
+  }
+
+  private Optional<Game> loadGameFromZip(Path zip) {
+    try {
+      return Optional.ofNullable(loader.loadFromZip(zip));
+    } catch (IOException e) {
+      log.log(Level.WARNING, "Could not load game from ZIP file " + zip.toAbsolutePath(), e);
+    } catch (DuplicateGameException e) {
+      log.warning("Duplicate game name in ZIP file " + zip.toAbsolutePath() + ": " + e.getMessage());
+    } catch (RuntimeException e) { // NOPMD
+      log.log(Level.WARNING, "General exception when loading from ZIP file " + zip.toAbsolutePath(), e);
+    }
+    return Optional.empty();
+  }
+
+  private List<Path> scanForZips() throws IOException {
+    return Files.list(Paths.get(directory))
+        .filter(path -> path.toString().endsWith(".zip"))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Gets the list of discovered games. The list will be empty until {@link #refresh()} is called.
+   */
+  public List<Game> getGames() {
+    return games;
+  }
+
+  /**
+   * Refreshes the list of discovered games.
+   */
+  public List<Game> refresh() {
+    try {
+      List<Game> foundGames = findGames();
+      games.clear();
+      games.addAll(foundGames);
+    } catch (IOException e) {
+      log.log(Level.WARNING, "Could not refresh game extensions", e);
+    }
+    return games;
+  }
+
+}

--- a/src/main/resources/edu/wpi/first/pathweaver/2018-powerup.json
+++ b/src/main/resources/edu/wpi/first/pathweaver/2018-powerup.json
@@ -1,0 +1,10 @@
+{
+  "game": "FIRST Power Up",
+  "field-image": "2018-field.jpg",
+  "field-corners": {
+    "top-left": [125, 20],
+    "bottom-right": [827, 370]
+  },
+  "field-size": [54, 27],
+  "field-unit": "feet"
+}

--- a/src/test/java/edu/wpi/first/pathweaver/extensions/GameLoaderTest.java
+++ b/src/test/java/edu/wpi/first/pathweaver/extensions/GameLoaderTest.java
@@ -1,0 +1,39 @@
+package edu.wpi.first.pathweaver.extensions;
+
+import si.uom.impl.quantity.LengthAmount;
+
+import edu.wpi.first.pathweaver.Game;
+import edu.wpi.first.pathweaver.PathUnits;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts") // PMD doesn't quite understand assertAll()
+public class GameLoaderTest {
+
+  @Test
+  @SuppressWarnings("PMD.JUnitAssertionsShouldIncludeMessage") // False positive on the messages in the last 2 asserts
+  public void testSimpleJson() {
+    ExtensionLoader loader = new ExtensionLoader();
+    String json = "{"
+        + "\"" + ExtensionLoader.GAME_NAME_KEY + "\": \"TestGame\","
+        + "\"" + ExtensionLoader.FIELD_IMAGE_KEY + "\": \"img.png\","
+        + "\"" + ExtensionLoader.FIELD_CORNERS_KEY + "\": {"
+        + "\"" + ExtensionLoader.TOP_LEFT_KEY + "\": [0, 0],"
+        + "\"" + ExtensionLoader.BOTTOM_RIGHT_KEY + "\": [4, 2]"
+        + "},"
+        + "\"" + ExtensionLoader.FIELD_SIZE_KEY + "\": [16, 8],"
+        + "\"" + ExtensionLoader.FIELD_UNITS_KEY + "\": \"feet\""
+        + "}";
+    Game extension = loader.loadFromJsonString(name -> null, json);
+    assertAll("Loading from JSON",
+        () -> assertEquals("TestGame", extension.getName(), "Wrong name"),
+        () -> assertEquals(0.25, extension.getField().getScale(), "Wrong scale"),
+        () -> assertEquals(new LengthAmount(16, PathUnits.FOOT), extension.getField().getRealWidth(), "Wrong width"),
+        () -> assertEquals(new LengthAmount(8, PathUnits.FOOT), extension.getField().getRealLength(), "Wrong length")
+    );
+  }
+
+}


### PR DESCRIPTION
Games are defined with a json file to specify the game and field layout, and an image file for the field.

Games are loaded from the  `~/PathWeaver/Games` directory. The files can be in either a game-specific subdirectory, or in a zip file in the games directory. The ZIP file must follow the same layout as a game directory; the JSON file must be in the root of the ZIP file (cannot be in a subdirectory).

## File Layout
```
~/PathWeaver
  /Games
    /Custom Game
      custom-game.json
      field-image.png
    OtherGame.zip
```

## JSON Format

```
{
  "game": "game name",
  "field-image": "relative/path/to/img.png",
  "field-corners": {
    "top-left": [x, y],
    "bottom-right": [x, y]
  },
  "field-size": [width, length],
  "field-unit": "unit name"
}
```
The path to the field image is relative to the JSON file. For simplicity, the image file should be in the same directory as the JSON file.  
The field corners are the X and Y coordinates of the top-left and bottom-right pixels defining the rectangular boundary of the playable area in the field image. Non-rectangular playing areas are not supported.  
The field size is the width and length of the playable area of the field in the provided units.  
The field units are case-insensitive and can be in meters, cm, mm, inches, feet, yards, or miles. Singular, plural, and abbreviations are supported (eg `"meter"`, `"meters"`, and `"m"` are all valid for specifying meters)