### PR TITLE
Add support for specific output folder and FRC deployment

### DIFF
--- a/src/main/java/edu/wpi/first/pathweaver/CreateProjectController.java
+++ b/src/main/java/edu/wpi/first/pathweaver/CreateProjectController.java
@@ -186,6 +186,7 @@ public class CreateProjectController {
   }
 
   @FXML
+  @SuppressWarnings("PMD.NcssCount")
   private void createProject() {
     String folderString = directory.getText().trim();
     // create a "PathWeaver" subdirectory if not editing an existing project

--- a/src/main/java/edu/wpi/first/pathweaver/CreateProjectController.java
+++ b/src/main/java/edu/wpi/first/pathweaver/CreateProjectController.java
@@ -37,6 +37,8 @@ public class CreateProjectController {
   @FXML
   private Button browse;
   @FXML
+  private Button browseOutput;
+  @FXML
   private Button create;
   @FXML
   private Button cancel;
@@ -44,6 +46,8 @@ public class CreateProjectController {
   private VBox vBox;
   @FXML
   private TextField directory;
+  @FXML
+  private TextField outputDirectory;
   @FXML
   private TextField timeStep;
   @FXML
@@ -59,7 +63,11 @@ public class CreateProjectController {
   @FXML
   private ChoiceBox<Unit<Length>> length;
   @FXML
+  private Label browseLabel;
+  @FXML
   private Label timeLabel;
+  @FXML
+  private Label outputLabel;
   @FXML
   private Label velocityLabel;
   @FXML
@@ -89,6 +97,8 @@ public class CreateProjectController {
     ObservableList<TextField> allFields = FXCollections.observableArrayList(numericFields);
     allFields.add(directory);
 
+    var directoryControls = List.of(browseLabel, directory, browse);
+    var outputControls = List.of(outputLabel, outputDirectory, browseOutput);
     var timeControls = List.of(timeLabel, timeStep, timeUnits);
     var velocityControls = List.of(velocityLabel, maxVelocity, velocityUnits);
     var accelerationControls = List.of(accelerationLabel, maxAcceleration, accelerationUnits); // NOPMD
@@ -135,6 +145,16 @@ public class CreateProjectController {
     });
 
     var lengthUnit = EasyBind.monadic(length.getSelectionModel().selectedItemProperty());
+    directoryControls.forEach(control -> control
+        .setTooltip(new Tooltip("The directory to store your project.\n"
+            + "It will be stored at a PathWeaver subdirectory of this location.\n"
+            + "It is recommended this be the root folder of your robot code\n"
+            + "to simplify version control and path deployment.")));
+    outputControls.forEach(control -> control
+        .setTooltip(new Tooltip("(Optional) The directory to output paths to.\n"
+            + "If it is the root folder of your FRC robot project,\nthe paths will automatically be copied to the "
+            + "robot at deploy time.\nDefault: will search relative to your project directory,\n"
+            + "attempting to find deploy folder.")));
     timeControls.forEach(control -> control
         .setTooltip(new Tooltip("Time delta between points")));
     velocityControls.forEach(control -> control
@@ -150,7 +170,12 @@ public class CreateProjectController {
     wheelBaseControls.forEach(control -> control
         .setTooltip(new Tooltip("Distance between the left and right of the wheel base.")));
     wheelBaseUnits.textProperty().bind(lengthUnit.map(SimpleUnitFormat.getInstance()::format));
-    Stream.of(timeControls, velocityControls, accelerationControls, jerkControls, wheelBaseControls)
+    // Show longer text for an extended period of time
+    Stream.of(directoryControls, outputControls)
+        .flatMap(List::stream)
+        .forEach(control -> control.getTooltip().setShowDuration(Duration.seconds(10)));
+    Stream.of(directoryControls, outputControls, timeControls, velocityControls, accelerationControls, jerkControls,
+        wheelBaseControls)
         .flatMap(List::stream)
         .forEach(control -> control.getTooltip().setShowDelay(Duration.millis(150)));
 
@@ -167,6 +192,14 @@ public class CreateProjectController {
     File directory = editing ? new File(folderString) : new File(folderString, "PathWeaver");
     editing = false;
     directory.mkdir();
+    String outputString = outputDirectory.getText().trim();
+    String outputPath = null;
+    if (!outputString.isEmpty()) {
+      // Find the relative path for the output directory to the project directory, using / file separators
+      outputPath = directory.toPath().relativize(new File(outputString).toPath()).toString()
+          .replace("\\", "/");
+      directory.toPath().relativize(directory.toPath());
+    }
     ProgramPreferences.getInstance().addProject(directory.getAbsolutePath());
     String lengthUnit = length.getValue().getName();
     double timeDelta = Double.parseDouble(timeStep.getText());
@@ -175,7 +208,7 @@ public class CreateProjectController {
     double jerkMax = Double.parseDouble(maxJerk.getText());
     double wheelBaseDistance = Double.parseDouble(wheelBase.getText());
     ProjectPreferences.Values values = new ProjectPreferences.Values(lengthUnit, timeDelta, velocityMax,
-        accelerationMax, jerkMax, wheelBaseDistance, game.getValue().getName());
+        accelerationMax, jerkMax, wheelBaseDistance, game.getValue().getName(), outputPath);
     ProjectPreferences prefs = ProjectPreferences.getInstance(directory.getAbsolutePath());
     prefs.setValues(values);
     FxUtils.loadMainScreen(vBox.getScene(), getClass());
@@ -183,11 +216,20 @@ public class CreateProjectController {
 
   @FXML
   private void browseDirectory() {
+    browse(directory);
+  }
+
+  @FXML
+  private void browseOutput() {
+    browse(outputDirectory);
+  }
+
+  private void browse(TextField location) {
     DirectoryChooser chooser = new DirectoryChooser();
     File selectedDirectory = chooser.showDialog(vBox.getScene().getWindow());
     if (selectedDirectory != null) {
-      directory.setText(selectedDirectory.getPath());
-      directory.positionCaret(selectedDirectory.getPath().length());
+      location.setText(selectedDirectory.getPath());
+      location.positionCaret(selectedDirectory.getPath().length());
     }
   }
 
@@ -200,6 +242,7 @@ public class CreateProjectController {
   private void setupEditProject() {
     ProjectPreferences.Values values = ProjectPreferences.getInstance().getValues();
     directory.setText(ProjectPreferences.getInstance().getDirectory());
+    outputDirectory.setText(ProjectPreferences.getInstance().getValues().getOutputDir());
     create.setText("Edit Project");
     title.setText("Edit Project");
     browse.setVisible(false);

--- a/src/main/java/edu/wpi/first/pathweaver/CreateProjectController.java
+++ b/src/main/java/edu/wpi/first/pathweaver/CreateProjectController.java
@@ -199,7 +199,6 @@ public class CreateProjectController {
       // Find the relative path for the output directory to the project directory, using / file separators
       outputPath = directory.toPath().relativize(new File(outputString).toPath()).toString()
           .replace("\\", "/");
-      directory.toPath().relativize(directory.toPath());
     }
     ProgramPreferences.getInstance().addProject(directory.getAbsolutePath());
     String lengthUnit = length.getValue().getName();

--- a/src/main/java/edu/wpi/first/pathweaver/MainController.java
+++ b/src/main/java/edu/wpi/first/pathweaver/MainController.java
@@ -347,7 +347,8 @@ public class MainController {
     try {
       alert.setContentText("Paths exported to: " + output.getCanonicalPath());
     } catch (IOException e) {
-      e.printStackTrace();
+      Logger log = Logger.getLogger(MainController.class.getName());
+      log.log(Level.WARNING, "Could not export to " + output.getPath(), e);
     }
     alert.show();
   }

--- a/src/main/java/edu/wpi/first/pathweaver/MainController.java
+++ b/src/main/java/edu/wpi/first/pathweaver/MainController.java
@@ -335,11 +335,11 @@ public class MainController {
     for (TreeItem<String> pathName : pathRoot.getChildren()) {
       Path path = PathIOUtil.importPath(pathDirectory, pathName.getValue());
       TankModifier tank = path.getTankModifier();
-      Pathfinder.writeToCSV(new File(output, path.getPathNameNoExtension() + ".v1.csv"),
+      Pathfinder.writeToCSV(new File(output, path.getPathNameNoExtension() + ".pf1.csv"),
           tank.getSourceTrajectory());
-      Pathfinder.writeToCSV(new File(output, path.getPathNameNoExtension() + ".left.v1.csv"),
+      Pathfinder.writeToCSV(new File(output, path.getPathNameNoExtension() + ".left.pf1.csv"),
           tank.getLeftTrajectory());
-      Pathfinder.writeToCSV(new File(output, path.getPathNameNoExtension() + ".right.v1.csv"),
+      Pathfinder.writeToCSV(new File(output, path.getPathNameNoExtension() + ".right.pf1.csv"),
           tank.getRightTrajectory());
     }
     Alert alert = new Alert(Alert.AlertType.INFORMATION);

--- a/src/main/java/edu/wpi/first/pathweaver/MainController.java
+++ b/src/main/java/edu/wpi/first/pathweaver/MainController.java
@@ -14,6 +14,7 @@ import javafx.beans.value.ObservableValue;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
+import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
@@ -43,7 +44,6 @@ public class MainController {
   private String directory = ProjectPreferences.getInstance().getDirectory();
   private final String pathDirectory = directory + "/Paths/";
   private final String autonDirectory = directory + "/Autons/";
-  private final String outputDirectory = directory + "/output/";
   private final TreeItem<String> autonRoot = new TreeItem<>("Autons");
   private final TreeItem<String> pathRoot = new TreeItem<>("Paths");
 
@@ -330,15 +330,26 @@ public class MainController {
     if (!SaveManager.getInstance().promptSaveAll()) {
       return;
     }
-    new File(outputDirectory).mkdir();
+    File output = ProjectPreferences.getInstance().getOutputDir();
+    output.mkdirs();
     for (TreeItem<String> pathName : pathRoot.getChildren()) {
       Path path = PathIOUtil.importPath(pathDirectory, pathName.getValue());
       TankModifier tank = path.getTankModifier();
-      Pathfinder.writeToCSV(new File(outputDirectory + path.getPathNameNoExtension() + "_left.csv"),
+      Pathfinder.writeToCSV(new File(output, path.getPathNameNoExtension() + ".v1.csv"),
+          tank.getSourceTrajectory());
+      Pathfinder.writeToCSV(new File(output, path.getPathNameNoExtension() + ".left.v1.csv"),
           tank.getLeftTrajectory());
-      Pathfinder.writeToCSV(new File(outputDirectory + path.getPathNameNoExtension() + "_right.csv"),
+      Pathfinder.writeToCSV(new File(output, path.getPathNameNoExtension() + ".right.v1.csv"),
           tank.getRightTrajectory());
     }
+    Alert alert = new Alert(Alert.AlertType.INFORMATION);
+    alert.setTitle("Paths exported!");
+    try {
+      alert.setContentText("Paths exported to: " + output.getCanonicalPath());
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    alert.show();
   }
 
   @FXML

--- a/src/main/java/edu/wpi/first/pathweaver/ProjectPreferences.java
+++ b/src/main/java/edu/wpi/first/pathweaver/ProjectPreferences.java
@@ -36,13 +36,14 @@ public class ProjectPreferences {
   }
 
   private void setDefaults() {
-    values = new Values("FOOT", 0.2, 10.0, 60.0, 60.0, 2.0, Game.POWER_UP_2018.getName());
+    values = new Values("FOOT", 0.2, 10.0, 60.0, 60.0, 2.0, Game.POWER_UP_2018.getName(), null);
     updateValues();
   }
 
   private void updateValues() {
     try {
       Gson gson = new GsonBuilder().setPrettyPrinting().create();
+      new File(directory).mkdirs();
       FileWriter writer = new FileWriter(directory + FILENAME);
       gson.toJson(values, writer);
       writer.close();
@@ -113,6 +114,42 @@ public class ProjectPreferences {
     return field;
   }
 
+  /**
+   * Returns the folder to output the generated paths to.
+   * @return File object of Folder to output generated paths to.
+   */
+  public File getOutputDir() {
+    if (values.getOutputDir() == null) {
+      File parentDirectory = new File(directory).getParentFile();
+      return getOutputDir(parentDirectory);
+    } else {
+      File output = new File(directory, values.getOutputDir());
+      return getOutputDir(output);
+    }
+  }
+
+  /**
+   * Returns the output directory relative to a specified directory. If the directory is an FRC project, it returns
+   * the proper deploy directory. Otherwise it simply returns the output subdirectory.
+   * @param directory Directory to return output directory for.
+   * @return A File that is the output directory.
+   */
+  private File getOutputDir(File directory) {
+    if (isFRCProject(directory)) {
+      return getDeployDirectory(directory);
+    } else {
+      return new File(directory, "output");
+    }
+  }
+
+  private File getDeployDirectory(File directory) {
+    return new File(directory, "src/main/deploy/paths");
+  }
+
+  private boolean isFRCProject(File directory) {
+    return new File(directory, "build.gradle").exists();
+  }
+
   public Values getValues() {
     return values;
   }
@@ -125,6 +162,7 @@ public class ProjectPreferences {
     private final double maxJerk;
     private final double wheelBase;
     private String gameName;
+    private final String outputDir;
 
     /**
      * Constructor for Values of ProjectPreferences.
@@ -137,7 +175,7 @@ public class ProjectPreferences {
      * @param gameName            The year/FRC game
      */
     public Values(String lengthUnit, double timeStep, double maxVelocity, double maxAcceleration, double maxJerk,
-                  double wheelBase, String gameName) {
+                  double wheelBase, String gameName, String outputDir) {
       this.lengthUnit = lengthUnit;
       this.timeStep = timeStep;
       this.maxVelocity = maxVelocity;
@@ -145,6 +183,7 @@ public class ProjectPreferences {
       this.maxJerk = maxJerk;
       this.wheelBase = wheelBase;
       this.gameName = gameName;
+      this.outputDir = outputDir;
     }
 
     public Unit<Length> getLengthUnit() {
@@ -173,6 +212,10 @@ public class ProjectPreferences {
 
     public String getGameName() {
       return gameName;
+    }
+
+    public String getOutputDir() {
+      return outputDir;
     }
   }
 }

--- a/src/main/resources/edu/wpi/first/pathweaver/createProject.fxml
+++ b/src/main/resources/edu/wpi/first/pathweaver/createProject.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<VBox fx:id="vBox" alignment="CENTER" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="425.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="edu.wpi.first.pathweaver.CreateProjectController">
+<VBox fx:id="vBox" alignment="CENTER" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="500.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="edu.wpi.first.pathweaver.CreateProjectController">
    <children>
       <Label fx:id="title" text="Create Project...">
          <font>
@@ -35,39 +35,43 @@
             <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
             <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
             <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
          </rowConstraints>
          <padding>
             <Insets bottom="20.0" left="40.0" right="40.0" top="10.0" />
          </padding>
          <children>
-            <Label text="Project Directory" />
-            <Label fx:id="timeLabel" text="Time Step" GridPane.rowIndex="3" />
-            <Label fx:id="velocityLabel" text="Max Velocity" GridPane.rowIndex="4" />
-            <Label fx:id="accelerationLabel" text="Max Acceleration" GridPane.rowIndex="5" />
-            <Label fx:id="jerkLabel" text="Max Jerk" GridPane.rowIndex="6" />
-            <Label fx:id="wheelBaseLabel" text="Wheel Base" GridPane.rowIndex="7" />
+            <Label fx:id="browseLabel" text="Project Directory" />
+            <Label fx:id="timeLabel" text="Time Step" GridPane.rowIndex="4" />
+            <Label fx:id="velocityLabel" text="Max Velocity" GridPane.rowIndex="5" />
+            <Label fx:id="accelerationLabel" text="Max Acceleration" GridPane.rowIndex="6" />
+            <Label fx:id="jerkLabel" text="Max Jerk" GridPane.rowIndex="7" />
+            <Label fx:id="wheelBaseLabel" text="Wheel Base" GridPane.rowIndex="8" />
             <TextField fx:id="directory" editable="false" GridPane.columnIndex="1" />
             <Button fx:id="browse" mnemonicParsing="false" onAction="#browseDirectory" text="Browse" GridPane.columnIndex="2" />
-            <ChoiceBox fx:id="game" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-            <TextField fx:id="timeStep" GridPane.columnIndex="1" GridPane.rowIndex="3" />
-            <TextField fx:id="maxVelocity" GridPane.columnIndex="1" GridPane.rowIndex="4" />
-            <TextField fx:id="maxAcceleration" GridPane.columnIndex="1" GridPane.rowIndex="5" />
-            <TextField fx:id="maxJerk" GridPane.columnIndex="1" GridPane.rowIndex="6" />
-            <TextField fx:id="wheelBase" GridPane.columnIndex="1" GridPane.rowIndex="7" />
-            <Label fx:id="timeUnits" text="seconds" GridPane.columnIndex="2" GridPane.rowIndex="3" />
-            <Label fx:id="velocityUnits" GridPane.columnIndex="2" GridPane.rowIndex="4" />
-            <Label fx:id="accelerationUnits" GridPane.columnIndex="2" GridPane.rowIndex="5" />
-            <Label fx:id="jerkUnits" GridPane.columnIndex="2" GridPane.rowIndex="6" />
-            <Label fx:id="wheelBaseUnits" GridPane.columnIndex="2" GridPane.rowIndex="7" />
-            <ButtonBar GridPane.columnIndex="2" GridPane.rowIndex="8">
+            <TextField fx:id="outputDirectory" editable="false" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+            <Button fx:id="browseOutput" mnemonicParsing="false" onAction="#browseOutput" text="Browse" GridPane.columnIndex="2" GridPane.rowIndex="1" />
+            <ChoiceBox fx:id="game" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+            <ChoiceBox fx:id="length" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+            <TextField fx:id="timeStep" GridPane.columnIndex="1" GridPane.rowIndex="4" />
+            <TextField fx:id="maxVelocity" GridPane.columnIndex="1" GridPane.rowIndex="5" />
+            <TextField fx:id="maxAcceleration" GridPane.columnIndex="1" GridPane.rowIndex="6" />
+            <TextField fx:id="maxJerk" GridPane.columnIndex="1" GridPane.rowIndex="7" />
+            <TextField fx:id="wheelBase" GridPane.columnIndex="1" GridPane.rowIndex="8" />
+            <Label fx:id="timeUnits" text="seconds" GridPane.columnIndex="2" GridPane.rowIndex="4" />
+            <Label fx:id="velocityUnits" GridPane.columnIndex="2" GridPane.rowIndex="5" />
+            <Label fx:id="accelerationUnits" GridPane.columnIndex="2" GridPane.rowIndex="6" />
+            <Label fx:id="jerkUnits" GridPane.columnIndex="2" GridPane.rowIndex="7" />
+            <Label fx:id="wheelBaseUnits" GridPane.columnIndex="2" GridPane.rowIndex="8" />
+            <ButtonBar GridPane.columnIndex="2" GridPane.rowIndex="9">
               <buttons>
                 <Button fx:id="cancel" mnemonicParsing="false" onAction="#cancel" text="Cancel" />
                   <Button fx:id="create" mnemonicParsing="false" onAction="#createProject" text="Create Project" />
               </buttons>
             </ButtonBar>
-            <Label text="Game" GridPane.rowIndex="1" />
-            <ChoiceBox fx:id="length" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="2" />
-            <Label text="Length Unit" GridPane.rowIndex="2" />
+            <Label text="Game" GridPane.rowIndex="2" />
+            <Label text="Length Unit" GridPane.rowIndex="3" />
+            <Label fx:id="outputLabel" text="Output Directory" GridPane.rowIndex="1" />
          </children>
       </GridPane>
    </children>

--- a/src/main/resources/edu/wpi/first/pathweaver/welcomeScreen.fxml
+++ b/src/main/resources/edu/wpi/first/pathweaver/welcomeScreen.fxml
@@ -10,7 +10,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<BorderPane fx:id="borderPane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="425.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="edu.wpi.first.pathweaver.WelcomeController">
+<BorderPane fx:id="borderPane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="500.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="edu.wpi.first.pathweaver.WelcomeController">
    <opaqueInsets>
       <Insets />
    </opaqueInsets>


### PR DESCRIPTION
This adds the option for a custom output folder for generated Paths. PathWeaver follows the following logic for identifying an output path:
If a output folder is specified:
1. Check if the output folder is the root of a FRC GradleRIO project. If it is output to src/main/deploy/paths
2. Otherwise simply deploy to the output subdirectory of that folder.

If no output folder is specified:
1. Check if the parent folder of the PathWeaver project is the root of a FRC GradleRIO project. If it is output to src/main/deploy/paths
2. Otherwise simply deploy to the output subdirectory of the PathWeaver project folder.

.CSV files are output for the center, left, and right trajectories with the filenames:
 `name.pf1.csv`, `name.left.pf1.csv`, `name.right.pf1.csv`