### PR TITLE
 Fix deletion issue with one path

### DIFF
--- a/src/main/java/edu/wpi/first/pathweaver/MainController.java
+++ b/src/main/java/edu/wpi/first/pathweaver/MainController.java
@@ -165,18 +165,15 @@ public class MainController {
       } else {
         removePath(selected);
       }
-    } else if (pathRoot == root) {
-      if (FxUtils.promptDelete(selected.getValue())) {
-        pathDisplayController.removeAllPath();
-        SaveManager.getInstance().removeChange(pathDisplayController.currentPathProperty().get());
-        MainIOUtil.deleteItem(pathDirectory, selected);
-        for (TreeItem<String> path : getAllInstances(selected)) {
-          removePath(path);
-        }
-        saveAllAutons();
-        loadAllAutons();
+    } else if (pathRoot == root && FxUtils.promptDelete(selected.getValue())) {
+      pathDisplayController.removeAllPath();
+      SaveManager.getInstance().removeChange(pathDisplayController.currentPathProperty().get());
+      MainIOUtil.deleteItem(pathDirectory, selected);
+      for (TreeItem<String> path : getAllInstances(selected)) {
+        removePath(path);
       }
-
+      saveAllAutons();
+      loadAllAutons();
     }
   }
 

--- a/src/main/java/edu/wpi/first/pathweaver/MainController.java
+++ b/src/main/java/edu/wpi/first/pathweaver/MainController.java
@@ -166,14 +166,17 @@ public class MainController {
         removePath(selected);
       }
     } else if (pathRoot == root) {
-      for (TreeItem<String> path : getAllInstances(selected)) {
-        removePath(path);
-      }
       if (FxUtils.promptDelete(selected.getValue())) {
+        pathDisplayController.removeAllPath();
+        SaveManager.getInstance().removeChange(pathDisplayController.currentPathProperty().get());
         MainIOUtil.deleteItem(pathDirectory, selected);
+        for (TreeItem<String> path : getAllInstances(selected)) {
+          removePath(path);
+        }
+        saveAllAutons();
+        loadAllAutons();
       }
-      saveAllAutons();
-      loadAllAutons();
+
     }
   }
 
@@ -226,7 +229,7 @@ public class MainController {
               return;
             }
             selected = newValue;
-            if (newValue != pathRoot) {
+            if (newValue != pathRoot && newValue != null) {
               pathDisplayController.removeAllPath();
               pathDisplayController.addPath(pathDirectory, newValue);
             }

--- a/src/main/java/edu/wpi/first/pathweaver/SaveManager.java
+++ b/src/main/java/edu/wpi/first/pathweaver/SaveManager.java
@@ -97,4 +97,12 @@ public final class SaveManager {
     }
   }
 
+  /**
+   * Removes a saved path from the list of saved paths.
+   * @param path The Path to no longer save.
+   */
+  public void removeChange(Path path) {
+    paths.remove(path);
+  }
+
 }


### PR DESCRIPTION
This fixes a problem where the paths on screen weren't cleared when a path was deleted in a project with a single path. Also fixes an issue where the user would be prompted to save a path that had already been deleted.