### PR TITLE
Fix issue with centimeter and millimeter

### DIFF
--- a/src/main/java/edu/wpi/first/pathweaver/PathDisplayController.java
+++ b/src/main/java/edu/wpi/first/pathweaver/PathDisplayController.java
@@ -162,8 +162,6 @@ public class PathDisplayController {
   }
 
   private void setupDrawPaneSizing(Image image) {
-    drawPane.setMaxWidth(image.getWidth());
-    drawPane.setMaxHeight(image.getHeight());
     drawPane.setPrefHeight(field.getRealLength().getValue().doubleValue());
     drawPane.setPrefWidth(field.getRealWidth().getValue().doubleValue());
     drawPane.setLayoutX(field.getCoord().getX());

--- a/src/main/java/edu/wpi/first/pathweaver/PathDisplayController.java
+++ b/src/main/java/edu/wpi/first/pathweaver/PathDisplayController.java
@@ -67,7 +67,7 @@ public class PathDisplayController {
         topPane.widthProperty(), topPane.heightProperty()));
 
     group.getTransforms().add(scale);
-    setupDrawPaneSizing(image);
+    setupDrawPaneSizing();
     new DragHandler(this, drawPane); // Handler doesn't need to be kept around by this, so just do setup
     setupPress();
     setupPathListeners();
@@ -161,7 +161,7 @@ public class PathDisplayController {
     }
   }
 
-  private void setupDrawPaneSizing(Image image) {
+  private void setupDrawPaneSizing() {
     drawPane.setPrefHeight(field.getRealLength().getValue().doubleValue());
     drawPane.setPrefWidth(field.getRealWidth().getValue().doubleValue());
     drawPane.setLayoutX(field.getCoord().getX());


### PR DESCRIPTION
This fixes #133. This issue was caused by a units mismatch. If the size of the field in the units being used was larger than the size of the image in pixels, it caused an issue with the field overlay.