### PR TITLE
Export path configs as JSON

### DIFF
--- a/src/main/java/edu/wpi/first/pathweaver/PathIOUtil.java
+++ b/src/main/java/edu/wpi/first/pathweaver/PathIOUtil.java
@@ -1,10 +1,12 @@
 package edu.wpi.first.pathweaver;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
 import edu.wpi.first.pathweaver.path.Path;
 import edu.wpi.first.pathweaver.path.wpilib.WpilibPath;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.CSVRecord;
 
 import java.io.BufferedWriter;
@@ -13,6 +15,7 @@ import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -33,28 +36,153 @@ public final class PathIOUtil {
    *
    * @return true if successful file write was preformed
    */
+
   public static boolean export(String fileLocation, Path path) {
     try (
-        BufferedWriter writer = Files.newBufferedWriter(Paths.get(fileLocation + path.getPathName()));
-
-        CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT
-            .withHeader("X", "Y", "Tangent X", "Tangent Y", "Fixed Theta", "Reversed", "Name"))
+        BufferedWriter writer = Files.newBufferedWriter(Paths.get(fileLocation, path.getPathName()))
     ) {
-      for (Waypoint wp : path.getWaypoints()) {
-        double xPos = wp.getX();
-        double yPos = wp.getY();
-        double tangentX = wp.getTangentX();
-        double tangentY = wp.getTangentY();
-        String name = wp.getName();
-        csvPrinter.printRecord(xPos, yPos, tangentX, tangentY, wp.isLockTangent(), wp.isReversed(), name);
-      }
-      csvPrinter.flush();
+      Config config = new Config(path);
+      Gson gson = new GsonBuilder().setPrettyPrinting().create();
+      String contents = gson.toJson(config);
+      writer.write(contents);
     } catch (IOException except) {
       LOGGER.log(Level.WARNING, "Could not save Path file", except);
       return false;
     }
     return true;
   }
+
+  public static Path importPath(String fileLocation, String fileName) {
+    Config config = importV1Path(fileLocation, fileName, false);
+
+    // We were able to read the file as the JSON version. Just return it.
+    if (config != null) {
+      return config.toPath(fileName);
+    }
+
+    // Try to upconvert the old CSV style config file.
+    LOGGER.log(Level.INFO, "Could not read Path file. Will try to parse it as a legacy CSV file");
+    Config legacyPoints = importV0Path(fileLocation, fileName);
+    String newFileName = fileName + ".json";
+    export(fileLocation, legacyPoints.toPath(newFileName));
+    config = importV1Path(fileLocation, newFileName, true);
+    if (config == null) {
+      LOGGER.log(Level.WARNING, "Could not read it as a CSV file either");
+      return null;
+    }
+
+    // We were able to convert it. Delete the old file, and return the json version
+    try {
+      Files.delete(Paths.get(fileLocation, fileName));
+    } catch (IOException e) {
+      LOGGER.log(Level.WARNING, "Could not delete old file");
+    }
+
+    return config.toPath(newFileName);
+  }
+
+  private static class ConfigPoint {
+    private final double x;
+    private final double y;
+    private final double tangentX;
+    private final double tangentY;
+    private final boolean fixedTheta;
+    private final boolean reversed;
+    private final String name;
+
+    public ConfigPoint(Waypoint waypoint, double height) {
+
+      x = waypoint.getX();
+      y = height + waypoint.getY();
+      tangentX = waypoint.getTangentX();
+      tangentY = waypoint.getTangentY();
+      fixedTheta = waypoint.isLockTangent();
+      reversed = waypoint.isReversed();
+      name = waypoint.getName();
+    }
+
+    public ConfigPoint(CSVRecord csvRecord, double height) {
+      x = Double.parseDouble(csvRecord.get("X"));
+      y = height + Double.parseDouble(csvRecord.get("Y"));
+      tangentX = Double.parseDouble(csvRecord.get("Tangent X"));
+      tangentY = Double.parseDouble(csvRecord.get("Tangent Y"));
+      fixedTheta = Boolean.parseBoolean(csvRecord.get("Fixed Theta"));
+      reversed = Boolean.parseBoolean(csvRecord.get("Reversed"));
+      if (csvRecord.isMapped("Name")) {
+        name = csvRecord.get("Name");
+      } else {
+        name = "";
+      }
+    }
+
+    public Waypoint toWaypoint(double height) {
+      Point2D position = new Point2D(x,  y - height);
+      Point2D tangent = new Point2D(tangentX, tangentY);
+      Waypoint waypoint = new Waypoint(position, tangent, fixedTheta, reversed);
+      waypoint.setName(name);
+
+      return waypoint;
+    }
+
+    @Override
+    public String toString() {
+      return "ConfigPoint{" +
+              "x=" + x +
+              ", y=" + y +
+              ", tangentX=" + tangentX +
+              ", tangentY=" + tangentY +
+              ", fixedTheta=" + fixedTheta +
+              ", reversed=" + reversed +
+              ", name='" + name + '\'' +
+              '}';
+    }
+  }
+
+
+  private static class Config {
+    private static final String VERSION = "v1";
+
+    public final String version = VERSION;
+    public final String lengthUnit = ProjectPreferences.getInstance().getValues().getLengthUnit().getName();
+    public final List<ConfigPoint> points = new ArrayList<>();
+
+    public Config() {
+    }
+
+    public Config(CSVParser csvParser) {
+      double height = ProjectPreferences.getInstance().getField().getRealLength().getValue().doubleValue();
+      for (CSVRecord csvRecord : csvParser) {
+        points.add(new ConfigPoint(csvRecord, height));
+      }
+    }
+
+
+    public Config(Path path) {
+      double height = ProjectPreferences.getInstance().getField().getRealLength().getValue().doubleValue();
+
+      for (Waypoint wp : path.getWaypoints()) {
+        points.add(new ConfigPoint(wp, height));
+      }
+    }
+
+    public Path toPath(String fileName) {
+      double height = ProjectPreferences.getInstance().getField().getRealLength().getValue().doubleValue();
+      ArrayList<Waypoint> waypoints = new ArrayList<>();
+      for (ConfigPoint point : points) {
+        waypoints.add(point.toWaypoint(height));
+      }
+
+      return new WpilibPath(waypoints, fileName);
+    }
+
+    @Override
+    public String toString() {
+      return "Config{" +
+              "points=" + points +
+              '}';
+    }
+  }
+
 
   /**
    * Imports Path object from disk.
@@ -64,34 +192,31 @@ public final class PathIOUtil {
    *
    * @return Path object saved in Path file
    */
-  public static Path importPath(String fileLocation, String fileName) {
+  private static Config importV0Path(String fileLocation, String fileName) {
     try(Reader reader = Files.newBufferedReader(java.nio.file.Path.of(fileLocation, fileName));
         CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
                 .withFirstRecordAsHeader()
                 .withIgnoreHeaderCase()
                 .withTrim())) {
-      ArrayList<Waypoint> waypoints = new ArrayList<>();
-      for (CSVRecord csvRecord : csvParser) {
-        Point2D position = new Point2D(
-                Double.parseDouble(csvRecord.get("X")),
-                Double.parseDouble(csvRecord.get("Y"))
-        );
-        Point2D tangent = new Point2D(
-                Double.parseDouble(csvRecord.get("Tangent X")),
-                Double.parseDouble(csvRecord.get("Tangent Y"))
-        );
-        boolean locked = Boolean.parseBoolean(csvRecord.get("Fixed Theta"));
-        boolean reversed = Boolean.parseBoolean(csvRecord.get("Reversed"));
-        Waypoint point = new Waypoint(position, tangent, locked, reversed);
-        if (csvRecord.isMapped("Name")) {
-          String name = csvRecord.get("Name");
-          point.setName(name);
-        }
-        waypoints.add(point);
-      }
-      return new WpilibPath(waypoints, fileName);
+      return new Config(csvParser);
     } catch (IOException except) {
       LOGGER.log(Level.WARNING, "Could not read Path file", except);
+      return null;
+    }
+  }
+
+  private static Config importV1Path(String fileLocation, String fileName, boolean logException) {
+    try (Reader reader = Files.newBufferedReader(java.nio.file.Path.of(fileLocation, fileName))) {
+      return new Gson().fromJson(reader, Config.class);
+    } catch (IOException ex) {
+      LOGGER.log(Level.WARNING, "Could not read Path file", ex);
+      return null;
+    }catch (JsonParseException ex) {
+      if (logException) {
+        LOGGER.log(Level.WARNING, "Could not parse json", ex);
+      } else {
+        LOGGER.log(Level.WARNING, "Could not parse json");
+      }
       return null;
     }
   }

--- a/src/test/java/edu/wpi/first/pathweaver/PathIOUtilTest.java
+++ b/src/test/java/edu/wpi/first/pathweaver/PathIOUtilTest.java
@@ -1,0 +1,183 @@
+package edu.wpi.first.pathweaver;
+
+import edu.wpi.first.pathweaver.path.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PathIOUtilTest {
+    private static final double EPSILON = 1e-5;
+
+    private String pathDirectory;
+    private String projectDirectory;
+
+    @BeforeEach
+    public void initialize(@TempDir java.nio.file.Path temp) throws IOException {
+        Files.createDirectories(temp.resolve("Paths/"));
+        projectDirectory = temp.toAbsolutePath().toString();
+        pathDirectory = temp.resolve("Paths/").toAbsolutePath().toString();
+    }
+
+    @Test
+    public void loadLegacyFileMeters() throws IOException {
+        String legacyFileName = "MetersLegacyPath.csv";
+        String pathweaverFile = "MetersPathweaverConfig.json";
+        setupConfigFiles(legacyFileName, pathweaverFile);
+        ProjectPreferences.getInstance(projectDirectory);
+
+        // We expect the legacy path to exist
+        assertTrue(Files.exists(Paths.get(pathDirectory, legacyFileName)));
+
+        Path path = PathIOUtil.importPath(pathDirectory, legacyFileName);
+        assertNotNull(path);
+        assertEquals(6, path.getWaypoints().size());
+
+
+        // Check that the points match
+        {
+            Waypoint waypoint = path.getWaypoints().get(0);
+            assertEquals(0.1, waypoint.getX(), EPSILON);
+            assertEquals(-7.01, waypoint.getY(), EPSILON);
+            assertEquals(10.5, waypoint.getTangentX(), EPSILON);
+            assertEquals(0, waypoint.getTangentY(), EPSILON);
+        }
+
+        {
+            Waypoint waypoint = path.getWaypoints().get(1);
+            assertEquals(7, waypoint.getX(), EPSILON);
+            assertEquals(-4.2, waypoint.getY(), EPSILON);
+            assertEquals(7.6, waypoint.getTangentX(), EPSILON);
+            assertEquals(0, waypoint.getTangentY(), EPSILON);
+        }
+
+        {
+            Waypoint waypoint = path.getWaypoints().get(2);
+            assertEquals(15.7, waypoint.getX(), EPSILON);
+            assertEquals(-0.16, waypoint.getY(), EPSILON);
+            assertEquals(0.35, waypoint.getTangentX(), EPSILON);
+            assertEquals(-2.56,waypoint.getTangentY(), EPSILON);
+        }
+
+        {
+            Waypoint waypoint = path.getWaypoints().get(3);
+            assertEquals(0.25, waypoint.getX(), EPSILON);
+            assertEquals(-0.11, waypoint.getY(), EPSILON);
+            assertEquals(1.3, waypoint.getTangentX(), EPSILON);
+            assertEquals(-5.2,waypoint.getTangentY(), EPSILON);
+        }
+
+        {
+            Waypoint waypoint = path.getWaypoints().get(4);
+            assertEquals(15.9, waypoint.getX(), EPSILON);
+            assertEquals(-8.11, waypoint.getY(), EPSILON);
+            assertEquals(-4.10, waypoint.getTangentX(), EPSILON);
+            assertEquals(0.69,waypoint.getTangentY(), EPSILON);
+        }
+
+        {
+            Waypoint waypoint = path.getWaypoints().get(5);
+            assertEquals(2.9, waypoint.getX(), EPSILON);
+            assertEquals(-4, waypoint.getY(), EPSILON);
+            assertEquals(-1.8, waypoint.getTangentX(), EPSILON);
+            assertEquals(0.0,waypoint.getTangentY(), EPSILON);
+        }
+    }
+
+
+    @Test
+    public void loadLegacyFileInches() throws IOException {
+        String legacyFileName = "InchesLegacyPath.csv";
+        String pathweaverFile = "InchesPathweaverConfig.json";
+        setupConfigFiles(legacyFileName, pathweaverFile);
+        ProjectPreferences.getInstance(projectDirectory);
+
+        // We expect the legacy path to exist
+        assertTrue(Files.exists(Paths.get(pathDirectory, legacyFileName)));
+
+        Path path = PathIOUtil.importPath(pathDirectory, legacyFileName);
+        assertNotNull(path);
+        assertEquals(7, path.getWaypoints().size());
+
+
+        // Check that the points match
+        {
+            Waypoint waypoint = path.getWaypoints().get(0);
+            assertEquals(4.7, waypoint.getX(), EPSILON);
+            assertEquals(-178, waypoint.getY(), EPSILON);
+            assertEquals(13.02, waypoint.getTangentX(), EPSILON);
+            assertEquals(-1.14, waypoint.getTangentY(), EPSILON);
+        }
+
+        {
+            Waypoint waypoint = path.getWaypoints().get(1);
+            assertEquals(180.5, waypoint.getX(), EPSILON);
+            assertEquals(-84.5, waypoint.getY(), EPSILON);
+            assertEquals(115.70, waypoint.getTangentX(), EPSILON);
+            assertEquals(1.32, waypoint.getTangentY(), EPSILON);
+        }
+
+        {
+            Waypoint waypoint = path.getWaypoints().get(2);
+            assertEquals(351.5, waypoint.getX(), EPSILON);
+            assertEquals(-163.5, waypoint.getY(), EPSILON);
+            assertEquals(7.27, waypoint.getTangentX(), EPSILON);
+            assertEquals(65.02,waypoint.getTangentY(), EPSILON);
+        }
+
+        {
+            Waypoint waypoint = path.getWaypoints().get(3);
+            assertEquals(317.0, waypoint.getX(), EPSILON);
+            assertEquals(-41.0, waypoint.getY(), EPSILON);
+            assertEquals(-64.72, waypoint.getTangentX(), EPSILON);
+            assertEquals(103.15,waypoint.getTangentY(), EPSILON);
+        }
+
+        {
+            Waypoint waypoint = path.getWaypoints().get(4);
+            assertEquals(49, waypoint.getX(), EPSILON);
+            assertEquals(-7.0, waypoint.getY(), EPSILON);
+            assertEquals(-36.09, waypoint.getTangentX(), EPSILON);
+            assertEquals(-15.08,waypoint.getTangentY(), EPSILON);
+        }
+
+        {
+            Waypoint waypoint = path.getWaypoints().get(5);
+            assertEquals(22.5, waypoint.getX(), EPSILON);
+            assertEquals(-45.5, waypoint.getY(), EPSILON);
+            assertEquals(-4.13, waypoint.getTangentX(), EPSILON);
+            assertEquals(-30.43,waypoint.getTangentY(), EPSILON);
+        }
+
+        {
+            Waypoint waypoint = path.getWaypoints().get(6);
+            assertEquals(57.5, waypoint.getX(), EPSILON);
+            assertEquals(-97.5, waypoint.getY(), EPSILON);
+            assertEquals(43.62, waypoint.getTangentX(), EPSILON);
+            assertEquals(-3.42,waypoint.getTangentY(), EPSILON);
+        }
+    }
+
+
+    private void extractResource(String resourceUrl, java.nio.file.Path destination) throws IOException {
+        try (InputStream stream = getClass().getResourceAsStream(resourceUrl)) {
+            if (stream == null) {
+                fail();
+            } else {
+                Files.copy(stream, destination, StandardCopyOption.REPLACE_EXISTING);
+            }
+        }
+    }
+
+    private void setupConfigFiles(String pathFile, String pathweaverFile) throws IOException {
+        extractResource("/edu/wpi/first/pathweaver/" + pathFile, Paths.get(pathDirectory, pathFile));
+        extractResource("/edu/wpi/first/pathweaver/" + pathweaverFile, Paths.get(projectDirectory, "pathweaver.json"));
+    }
+}

--- a/src/test/java/edu/wpi/first/pathweaver/PathIOUtilTest.java
+++ b/src/test/java/edu/wpi/first/pathweaver/PathIOUtilTest.java
@@ -29,6 +29,7 @@ public class PathIOUtilTest {
     @Test
     public void loadLegacyFileMeters() throws IOException {
         String legacyFileName = "MetersLegacyPath.csv";
+        String expectedFileName = "MetersExpectedPath.json";
         String pathweaverFile = "MetersPathweaverConfig.json";
         setupConfigFiles(legacyFileName, pathweaverFile);
         ProjectPreferences.getInstance(projectDirectory);
@@ -39,6 +40,9 @@ public class PathIOUtilTest {
         Path path = PathIOUtil.importPath(pathDirectory, legacyFileName);
         assertNotNull(path);
         assertEquals(6, path.getWaypoints().size());
+
+        // After loading, the legacy version should be deleted
+        assertFalse(Files.exists(Paths.get(pathDirectory, legacyFileName)));
 
 
         // Check that the points match
@@ -89,12 +93,20 @@ public class PathIOUtilTest {
             assertEquals(-1.8, waypoint.getTangentX(), EPSILON);
             assertEquals(0.0,waypoint.getTangentY(), EPSILON);
         }
+
+        // Make sure the path matches the one loaded from the expected file
+        extractResource("/edu/wpi/first/pathweaver/" + expectedFileName, Paths.get(pathDirectory, expectedFileName));
+
+        Path expectedPath = PathIOUtil.importPath(pathDirectory, expectedFileName);
+        assertEquals(expectedPath.getWaypoints(), path.getWaypoints(), "Path loaded from disk doesn't match original");
+
     }
 
 
     @Test
     public void loadLegacyFileInches() throws IOException {
         String legacyFileName = "InchesLegacyPath.csv";
+        String expectedFileName = "InchesExpectedPath.json";
         String pathweaverFile = "InchesPathweaverConfig.json";
         setupConfigFiles(legacyFileName, pathweaverFile);
         ProjectPreferences.getInstance(projectDirectory);
@@ -105,6 +117,9 @@ public class PathIOUtilTest {
         Path path = PathIOUtil.importPath(pathDirectory, legacyFileName);
         assertNotNull(path);
         assertEquals(7, path.getWaypoints().size());
+
+        // After loading, the legacy version should be deleted
+        assertFalse(Files.exists(Paths.get(pathDirectory, legacyFileName)));
 
 
         // Check that the points match
@@ -163,6 +178,13 @@ public class PathIOUtilTest {
             assertEquals(43.62, waypoint.getTangentX(), EPSILON);
             assertEquals(-3.42,waypoint.getTangentY(), EPSILON);
         }
+
+        // Make sure the path matches the one loaded from the expected file
+        extractResource("/edu/wpi/first/pathweaver/" + expectedFileName, Paths.get(pathDirectory, expectedFileName));
+
+        Path expectedPath = PathIOUtil.importPath(pathDirectory, expectedFileName);
+        assertEquals(expectedPath.getWaypoints(), path.getWaypoints(), "Path loaded from disk doesn't match original");
+
     }
 
 

--- a/src/test/java/edu/wpi/first/pathweaver/PathIOUtilTest.java
+++ b/src/test/java/edu/wpi/first/pathweaver/PathIOUtilTest.java
@@ -28,7 +28,7 @@ public class PathIOUtilTest {
 
     @Test
     public void loadLegacyFileMeters() throws IOException {
-        String legacyFileName = "MetersLegacyPath.csv";
+        String legacyFileName = "MetersLegacyPath.path";
         String expectedFileName = "MetersExpectedPath.json";
         String pathweaverFile = "MetersPathweaverConfig.json";
         setupConfigFiles(legacyFileName, pathweaverFile);
@@ -105,7 +105,7 @@ public class PathIOUtilTest {
 
     @Test
     public void loadLegacyFileInches() throws IOException {
-        String legacyFileName = "InchesLegacyPath.csv";
+        String legacyFileName = "InchesLegacyPath.path";
         String expectedFileName = "InchesExpectedPath.json";
         String pathweaverFile = "InchesPathweaverConfig.json";
         setupConfigFiles(legacyFileName, pathweaverFile);

--- a/src/test/resources/edu/wpi/first/pathweaver/InchesExpectedPath.json
+++ b/src/test/resources/edu/wpi/first/pathweaver/InchesExpectedPath.json
@@ -1,0 +1,69 @@
+{
+  "version": "v1",
+  "lengthUnit": "Inch",
+  "points": [
+    {
+      "x": 4.7,
+      "y": 2.0,
+      "tangentX": 13.02,
+      "tangentY": -1.14,
+      "fixedTheta": true,
+      "reversed": false,
+      "name": ""
+    },
+    {
+      "x": 180.5,
+      "y": 95.5,
+      "tangentX": 115.7,
+      "tangentY": 1.32,
+      "fixedTheta": false,
+      "reversed": false,
+      "name": ""
+    },
+    {
+      "x": 351.5,
+      "y": 16.5,
+      "tangentX": 7.27,
+      "tangentY": 65.02,
+      "fixedTheta": false,
+      "reversed": false,
+      "name": ""
+    },
+    {
+      "x": 317.0,
+      "y": 139.0,
+      "tangentX": -64.72,
+      "tangentY": 103.15,
+      "fixedTheta": false,
+      "reversed": false,
+      "name": ""
+    },
+    {
+      "x": 49.0,
+      "y": 173.0,
+      "tangentX": -36.09,
+      "tangentY": -15.08,
+      "fixedTheta": true,
+      "reversed": false,
+      "name": ""
+    },
+    {
+      "x": 22.5,
+      "y": 134.5,
+      "tangentX": -4.13,
+      "tangentY": -30.43,
+      "fixedTheta": false,
+      "reversed": false,
+      "name": ""
+    },
+    {
+      "x": 57.5,
+      "y": 82.5,
+      "tangentX": 43.62,
+      "tangentY": -3.42,
+      "fixedTheta": true,
+      "reversed": false,
+      "name": ""
+    }
+  ]
+}

--- a/src/test/resources/edu/wpi/first/pathweaver/InchesLegacyPath.path
+++ b/src/test/resources/edu/wpi/first/pathweaver/InchesLegacyPath.path
@@ -1,0 +1,8 @@
+X,Y,Tangent X,Tangent Y,Fixed Theta,Reversed,Name
+4.7,-178.0,13.02,-1.14,true,false,
+180.5,-84.5,115.70,1.32,false,false,
+351.5,-163.5,7.27,65.02,false,false,
+317.0,-41.0,-64.72,103.15,false,false,
+49,-7.0,-36.09,-15.08,true,false,
+22.5,-45.5,-4.13,-30.43,false,false,
+57.5,-97.5,43.62,-3.42,true,false,

--- a/src/test/resources/edu/wpi/first/pathweaver/InchesPathweaverConfig.json
+++ b/src/test/resources/edu/wpi/first/pathweaver/InchesPathweaverConfig.json
@@ -1,0 +1,9 @@
+{
+  "lengthUnit": "Inch",
+  "exportUnit": "Always Meters",
+  "maxVelocity": 60.0,
+  "maxAcceleration": 96.0,
+  "wheelBase": 24.0,
+  "gameName": "Galactic Search A",
+  "outputDir": ""
+}

--- a/src/test/resources/edu/wpi/first/pathweaver/MetersExpectedPath.json
+++ b/src/test/resources/edu/wpi/first/pathweaver/MetersExpectedPath.json
@@ -1,0 +1,58 @@
+{
+  "points": [
+    {
+      "x": 0.1,
+      "y": 1.2005499999999998,
+      "tangentX": 10.5,
+      "tangentY": 0.0,
+      "fixedTheta": true,
+      "reversed": false,
+      "name": ""
+    },
+    {
+      "x": 7.0,
+      "y": 4.010549999999999,
+      "tangentX": 7.6,
+      "tangentY": 0.0,
+      "fixedTheta": true,
+      "reversed": false,
+      "name": ""
+    },
+    {
+      "x": 15.7,
+      "y": 8.05055,
+      "tangentX": 0.35,
+      "tangentY": -2.56,
+      "fixedTheta": true,
+      "reversed": false,
+      "name": ""
+    },
+    {
+      "x": 0.25,
+      "y": 8.10055,
+      "tangentX": 1.3,
+      "tangentY": -5.2,
+      "fixedTheta": true,
+      "reversed": false,
+      "name": ""
+    },
+    {
+      "x": 15.9,
+      "y": 0.10055000000000014,
+      "tangentX": -4.1,
+      "tangentY": 0.69,
+      "fixedTheta": false,
+      "reversed": false,
+      "name": ""
+    },
+    {
+      "x": 2.9,
+      "y": 4.21055,
+      "tangentX": -1.8,
+      "tangentY": 0.0,
+      "fixedTheta": true,
+      "reversed": false,
+      "name": ""
+    }
+  ]
+}

--- a/src/test/resources/edu/wpi/first/pathweaver/MetersExpectedPath.json
+++ b/src/test/resources/edu/wpi/first/pathweaver/MetersExpectedPath.json
@@ -1,4 +1,6 @@
 {
+  "version": "v1",
+  "lengthUnit": "Meter",
   "points": [
     {
       "x": 0.1,

--- a/src/test/resources/edu/wpi/first/pathweaver/MetersLegacyPath.path
+++ b/src/test/resources/edu/wpi/first/pathweaver/MetersLegacyPath.path
@@ -1,0 +1,7 @@
+X,Y,Tangent X,Tangent Y,Fixed Theta,Reversed,Name
+0.1,-7.01,10.5,0.0,true,false,
+7.0,-4.2,7.6,0.0,true,false,
+15.7,-0.16,0.35,-2.56,true,false,
+0.25,-0.11,1.3,-5.2,true,false,
+15.9,-8.11,-4.1,0.69,false,false,
+2.9,-4.0,-1.8,0.0,true,false,

--- a/src/test/resources/edu/wpi/first/pathweaver/MetersPathweaverConfig.json
+++ b/src/test/resources/edu/wpi/first/pathweaver/MetersPathweaverConfig.json
@@ -1,0 +1,9 @@
+{
+  "lengthUnit": "Meter",
+  "exportUnit": "Always Meters",
+  "maxVelocity": 2.0,
+  "maxAcceleration": 2.0,
+  "trackWidth": 1.0,
+  "gameName": "Infinite Recharge 2021",
+  "outputDir": ""
+}


### PR DESCRIPTION
This should make it easier for robot code to pull in the config file, rather than having to parse the CSV and deal with the TopLeft coordinate system (and having to compensate for the field height), rather than wpilibs BottomLeft coordinate system. This should make it much easier to use pathweaver to graphically draw the waypoints, but use your own code to generate the trajectory so you can choose between quintic/cubic, and specify different max velocity/acceleration for different paths.

I made two commits, a unit test that checks the loading before any changes were made, and another which makes the changes. This should give some piece of mind that everything else should still work despite the change in config structure.

I used the same names as present in the CSV file, but am willing to change. I also added a version indicator, so if something else comes along that wants to do a different schema (waymaker, adding constraints to the file, etc) the can bump the version and make another up-converter.

I tried to be as unintrusive as possble, and kept all the changes to the the import/export class.