### PR TITLE
Fix NPE when launching with corrupt preferences

### DIFF
--- a/src/main/java/edu/wpi/first/pathweaver/ProgramPreferences.java
+++ b/src/main/java/edu/wpi/first/pathweaver/ProgramPreferences.java
@@ -34,7 +34,6 @@ public class ProgramPreferences {
 			updatePrefs();
 		} catch (JsonParseException e) {
 			Alert alert = new Alert(Alert.AlertType.ERROR);
-			FxUtils.applyDarkMode(alert);
 			alert.setTitle("Preferences import error");
 			alert.setContentText(
 					"Preferences have been reset due to file corruption. You may reimport your projects with the 'Import Project' button");


### PR DESCRIPTION
When launching with corrupt preferences, `ProgramPreferences` opens a new Alert to alert the user. It also applies dark mode with `FxUtils.applyDarkMode()`, which accesses `PathWeaver.mainScene`, which hasn't been initialized yet (`ProgramPreferences` is first called during `WelcomeController.initialize()`). This causes a NullPointerException

Removing the call to `applyDarkMode()` fixes this, and doesn't affect behavior since the program launches in light mode anyway.
